### PR TITLE
Add a use case and test for uri parameters, fix other test

### DIFF
--- a/tornroutes/__init__.py
+++ b/tornroutes/__init__.py
@@ -34,6 +34,13 @@ class route(object):
             goto = self.reverse_url('SomeRequestHandler')
             self.redirect(goto)
 
+    # for passing uri parameters
+    @route(r'/some/(?P<parameterized>\w+)/path')
+    class SomeParameterizedRequestHandler(RequestHandler):
+        def get(self, parameterized):
+            goto = self.reverse_url(parameterized)
+            self.redirect(goto)
+
     my_routes = route.get_routes()
     ```
 


### PR DESCRIPTION
- This should make it more obvious that uri parameters are in
  fact supported.
- Fixed 'test_generic_render' test so that `byte` comparison
  passes in Python 3
